### PR TITLE
Add conditional BehaviorTree.CPP dependency declarations

### DIFF
--- a/roadmap_explorer/CMakeLists.txt
+++ b/roadmap_explorer/CMakeLists.txt
@@ -68,6 +68,16 @@ string(TOUPPER "$ENV{ROS_DISTRO}" ROS_DISTRO_UPPER)
 message(STATUS "Building for ROS distro: ${ROS_DISTRO_UPPER}")
 add_compile_definitions(ROS_DISTRO_${ROS_DISTRO_UPPER})
 
+if(ROS_DISTRO_UPPER STREQUAL "HUMBLE")
+  find_package(behaviortree_cpp_v3 REQUIRED)
+  list(APPEND dependencies behaviortree_cpp_v3)
+elseif(ROS_DISTRO_UPPER STREQUAL "JAZZY" OR ROS_DISTRO_UPPER STREQUAL "KILTED")
+  find_package(behaviortree_cpp REQUIRED)
+  list(APPEND dependencies behaviortree_cpp)
+else()
+  message(FATAL_ERROR "Unsupported ROS distro: ${ROS_DISTRO_UPPER}")
+endif()
+
 # add_compile_definitions(
 #   USE_RCLCPP_LOGGER
 # )

--- a/roadmap_explorer/package.xml
+++ b/roadmap_explorer/package.xml
@@ -32,7 +32,11 @@
   <depend>nav2_map_server</depend>
   <depend>boost</depend>
   <depend>nlohmann-json-dev</depend>
-  
+
+  <depend condition="$ROS_DISTRO == 'humble'">behaviortree_cpp_v3</depend>
+  <depend condition="$ROS_DISTRO == 'jazzy'">behaviortree_cpp</depend>
+  <depend condition="$ROS_DISTRO == 'kilted'">behaviortree_cpp</depend>
+    
   <build_depend>ros_environment</build_depend>
   
   <!-- Test dependencies -->


### PR DESCRIPTION
This PR adds explicit BehaviorTree.CPP dependency declarations for `roadmap_explorer`.

The package already directly includes BehaviorTree.CPP headers, with source-level distro handling:

- Humble: `behaviortree_cpp_v3/bt_factory.h`
- Jazzy/Kilted: `behaviortree_cpp/bt_factory.h`

Currently, `package.xml` and `CMakeLists.txt` only declare `nav2_behavior_tree`, relying on the BehaviorTree.CPP package being available transitively. Per REP 140, the directly used dependency should also be declared by this package.

Because this branch supports Humble, Jazzy, and Kilted, this PR uses REP 149 conditional dependencies in `package.xml`:

- `behaviortree_cpp_v3` on Humble
- `behaviortree_cpp` on Jazzy/Kilted

It also updates `CMakeLists.txt` to call the matching `find_package(...)` and append the selected package to the shared dependency list used by `ament_target_dependencies(...)` and `ament_export_dependencies(...)`.

Validation on Humble:

- `colcon build --packages-select roadmap_explorer` passed.
- CMake resolved `behaviortree_cpp_v3_DIR`.
- The built targets link against `BT::behaviortree_cpp_v3`.